### PR TITLE
feat(new-feature): Add content management and basic security setup

### DIFF
--- a/ContentManagement-BE/.gitattributes
+++ b/ContentManagement-BE/.gitattributes
@@ -1,0 +1,2 @@
+/mvnw text eol=lf
+*.cmd text eol=crlf

--- a/ContentManagement-BE/.gitignore
+++ b/ContentManagement-BE/.gitignore
@@ -1,0 +1,33 @@
+HELP.md
+target/
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/

--- a/ContentManagement-BE/.mvn/wrapper/maven-wrapper.properties
+++ b/ContentManagement-BE/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+wrapperVersion=3.3.2
+distributionType=only-script
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip

--- a/ContentManagement-BE/docker-compose.yml
+++ b/ContentManagement-BE/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  postgres:
+    image: postgres:latest
+    container_name: db
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: 1511
+      POSTGRES_DB: db
+    volumes:
+      - postgres_data:/var/lib/postgresql/db
+
+volumes:
+  postgres_data:

--- a/ContentManagement-BE/mvnw
+++ b/ContentManagement-BE/mvnw
@@ -1,0 +1,259 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
+# Apache Maven Wrapper startup batch script, version 3.3.2
+#
+# Optional ENV vars
+# -----------------
+#   JAVA_HOME - location of a JDK home dir, required when download maven via java source
+#   MVNW_REPOURL - repo url base for downloading maven distribution
+#   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+#   MVNW_VERBOSE - true: enable verbose log; debug: trace the mvnw script; others: silence the output
+# ----------------------------------------------------------------------------
+
+set -euf
+[ "${MVNW_VERBOSE-}" != debug ] || set -x
+
+# OS specific support.
+native_path() { printf %s\\n "$1"; }
+case "$(uname)" in
+CYGWIN* | MINGW*)
+  [ -z "${JAVA_HOME-}" ] || JAVA_HOME="$(cygpath --unix "$JAVA_HOME")"
+  native_path() { cygpath --path --windows "$1"; }
+  ;;
+esac
+
+# set JAVACMD and JAVACCMD
+set_java_home() {
+  # For Cygwin and MinGW, ensure paths are in Unix format before anything is touched
+  if [ -n "${JAVA_HOME-}" ]; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ]; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+      JAVACCMD="$JAVA_HOME/jre/sh/javac"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+      JAVACCMD="$JAVA_HOME/bin/javac"
+
+      if [ ! -x "$JAVACMD" ] || [ ! -x "$JAVACCMD" ]; then
+        echo "The JAVA_HOME environment variable is not defined correctly, so mvnw cannot run." >&2
+        echo "JAVA_HOME is set to \"$JAVA_HOME\", but \"\$JAVA_HOME/bin/java\" or \"\$JAVA_HOME/bin/javac\" does not exist." >&2
+        return 1
+      fi
+    fi
+  else
+    JAVACMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v java
+    )" || :
+    JAVACCMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v javac
+    )" || :
+
+    if [ ! -x "${JAVACMD-}" ] || [ ! -x "${JAVACCMD-}" ]; then
+      echo "The java/javac command does not exist in PATH nor is JAVA_HOME set, so mvnw cannot run." >&2
+      return 1
+    fi
+  fi
+}
+
+# hash string like Java String::hashCode
+hash_string() {
+  str="${1:-}" h=0
+  while [ -n "$str" ]; do
+    char="${str%"${str#?}"}"
+    h=$(((h * 31 + $(LC_CTYPE=C printf %d "'$char")) % 4294967296))
+    str="${str#?}"
+  done
+  printf %x\\n $h
+}
+
+verbose() { :; }
+[ "${MVNW_VERBOSE-}" != true ] || verbose() { printf %s\\n "${1-}"; }
+
+die() {
+  printf %s\\n "$1" >&2
+  exit 1
+}
+
+trim() {
+  # MWRAPPER-139:
+  #   Trims trailing and leading whitespace, carriage returns, tabs, and linefeeds.
+  #   Needed for removing poorly interpreted newline sequences when running in more
+  #   exotic environments such as mingw bash on Windows.
+  printf "%s" "${1}" | tr -d '[:space:]'
+}
+
+# parse distributionUrl and optional distributionSha256Sum, requires .mvn/wrapper/maven-wrapper.properties
+while IFS="=" read -r key value; do
+  case "${key-}" in
+  distributionUrl) distributionUrl=$(trim "${value-}") ;;
+  distributionSha256Sum) distributionSha256Sum=$(trim "${value-}") ;;
+  esac
+done <"${0%/*}/.mvn/wrapper/maven-wrapper.properties"
+[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in ${0%/*}/.mvn/wrapper/maven-wrapper.properties"
+
+case "${distributionUrl##*/}" in
+maven-mvnd-*bin.*)
+  MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/
+  case "${PROCESSOR_ARCHITECTURE-}${PROCESSOR_ARCHITEW6432-}:$(uname -a)" in
+  *AMD64:CYGWIN* | *AMD64:MINGW*) distributionPlatform=windows-amd64 ;;
+  :Darwin*x86_64) distributionPlatform=darwin-amd64 ;;
+  :Darwin*arm64) distributionPlatform=darwin-aarch64 ;;
+  :Linux*x86_64*) distributionPlatform=linux-amd64 ;;
+  *)
+    echo "Cannot detect native platform for mvnd on $(uname)-$(uname -m), use pure java version" >&2
+    distributionPlatform=linux-amd64
+    ;;
+  esac
+  distributionUrl="${distributionUrl%-bin.*}-$distributionPlatform.zip"
+  ;;
+maven-mvnd-*) MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/ ;;
+*) MVN_CMD="mvn${0##*/mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
+esac
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+[ -z "${MVNW_REPOURL-}" ] || distributionUrl="$MVNW_REPOURL$_MVNW_REPO_PATTERN${distributionUrl#*"$_MVNW_REPO_PATTERN"}"
+distributionUrlName="${distributionUrl##*/}"
+distributionUrlNameMain="${distributionUrlName%.*}"
+distributionUrlNameMain="${distributionUrlNameMain%-bin}"
+MAVEN_USER_HOME="${MAVEN_USER_HOME:-${HOME}/.m2}"
+MAVEN_HOME="${MAVEN_USER_HOME}/wrapper/dists/${distributionUrlNameMain-}/$(hash_string "$distributionUrl")"
+
+exec_maven() {
+  unset MVNW_VERBOSE MVNW_USERNAME MVNW_PASSWORD MVNW_REPOURL || :
+  exec "$MAVEN_HOME/bin/$MVN_CMD" "$@" || die "cannot exec $MAVEN_HOME/bin/$MVN_CMD"
+}
+
+if [ -d "$MAVEN_HOME" ]; then
+  verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  exec_maven "$@"
+fi
+
+case "${distributionUrl-}" in
+*?-bin.zip | *?maven-mvnd-?*-?*.zip) ;;
+*) die "distributionUrl is not valid, must match *-bin.zip or maven-mvnd-*.zip, but found '${distributionUrl-}'" ;;
+esac
+
+# prepare tmp dir
+if TMP_DOWNLOAD_DIR="$(mktemp -d)" && [ -d "$TMP_DOWNLOAD_DIR" ]; then
+  clean() { rm -rf -- "$TMP_DOWNLOAD_DIR"; }
+  trap clean HUP INT TERM EXIT
+else
+  die "cannot create temp dir"
+fi
+
+mkdir -p -- "${MAVEN_HOME%/*}"
+
+# Download and Install Apache Maven
+verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+verbose "Downloading from: $distributionUrl"
+verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+# select .zip or .tar.gz
+if ! command -v unzip >/dev/null; then
+  distributionUrl="${distributionUrl%.zip}.tar.gz"
+  distributionUrlName="${distributionUrl##*/}"
+fi
+
+# verbose opt
+__MVNW_QUIET_WGET=--quiet __MVNW_QUIET_CURL=--silent __MVNW_QUIET_UNZIP=-q __MVNW_QUIET_TAR=''
+[ "${MVNW_VERBOSE-}" != true ] || __MVNW_QUIET_WGET='' __MVNW_QUIET_CURL='' __MVNW_QUIET_UNZIP='' __MVNW_QUIET_TAR=v
+
+# normalize http auth
+case "${MVNW_PASSWORD:+has-password}" in
+'') MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+has-password) [ -n "${MVNW_USERNAME-}" ] || MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+esac
+
+if [ -z "${MVNW_USERNAME-}" ] && command -v wget >/dev/null; then
+  verbose "Found wget ... using wget"
+  wget ${__MVNW_QUIET_WGET:+"$__MVNW_QUIET_WGET"} "$distributionUrl" -O "$TMP_DOWNLOAD_DIR/$distributionUrlName" || die "wget: Failed to fetch $distributionUrl"
+elif [ -z "${MVNW_USERNAME-}" ] && command -v curl >/dev/null; then
+  verbose "Found curl ... using curl"
+  curl ${__MVNW_QUIET_CURL:+"$__MVNW_QUIET_CURL"} -f -L -o "$TMP_DOWNLOAD_DIR/$distributionUrlName" "$distributionUrl" || die "curl: Failed to fetch $distributionUrl"
+elif set_java_home; then
+  verbose "Falling back to use Java to download"
+  javaSource="$TMP_DOWNLOAD_DIR/Downloader.java"
+  targetZip="$TMP_DOWNLOAD_DIR/$distributionUrlName"
+  cat >"$javaSource" <<-END
+	public class Downloader extends java.net.Authenticator
+	{
+	  protected java.net.PasswordAuthentication getPasswordAuthentication()
+	  {
+	    return new java.net.PasswordAuthentication( System.getenv( "MVNW_USERNAME" ), System.getenv( "MVNW_PASSWORD" ).toCharArray() );
+	  }
+	  public static void main( String[] args ) throws Exception
+	  {
+	    setDefault( new Downloader() );
+	    java.nio.file.Files.copy( java.net.URI.create( args[0] ).toURL().openStream(), java.nio.file.Paths.get( args[1] ).toAbsolutePath().normalize() );
+	  }
+	}
+	END
+  # For Cygwin/MinGW, switch paths to Windows format before running javac and java
+  verbose " - Compiling Downloader.java ..."
+  "$(native_path "$JAVACCMD")" "$(native_path "$javaSource")" || die "Failed to compile Downloader.java"
+  verbose " - Running Downloader.java ..."
+  "$(native_path "$JAVACMD")" -cp "$(native_path "$TMP_DOWNLOAD_DIR")" Downloader "$distributionUrl" "$(native_path "$targetZip")"
+fi
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+if [ -n "${distributionSha256Sum-}" ]; then
+  distributionSha256Result=false
+  if [ "$MVN_CMD" = mvnd.sh ]; then
+    echo "Checksum validation is not supported for maven-mvnd." >&2
+    echo "Please disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  elif command -v sha256sum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  elif command -v shasum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | shasum -a 256 -c >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  else
+    echo "Checksum validation was requested but neither 'sha256sum' or 'shasum' are available." >&2
+    echo "Please install either command, or disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  fi
+  if [ $distributionSha256Result = false ]; then
+    echo "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised." >&2
+    echo "If you updated your Maven version, you need to update the specified distributionSha256Sum property." >&2
+    exit 1
+  fi
+fi
+
+# unzip and move
+if command -v unzip >/dev/null; then
+  unzip ${__MVNW_QUIET_UNZIP:+"$__MVNW_QUIET_UNZIP"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -d "$TMP_DOWNLOAD_DIR" || die "failed to unzip"
+else
+  tar xzf${__MVNW_QUIET_TAR:+"$__MVNW_QUIET_TAR"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -C "$TMP_DOWNLOAD_DIR" || die "failed to untar"
+fi
+printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/mvnw.url"
+mv -- "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
+
+clean || :
+exec_maven "$@"

--- a/ContentManagement-BE/mvnw.cmd
+++ b/ContentManagement-BE/mvnw.cmd
@@ -1,0 +1,149 @@
+<# : batch portion
+@REM ----------------------------------------------------------------------------
+@REM Licensed to the Apache Software Foundation (ASF) under one
+@REM or more contributor license agreements.  See the NOTICE file
+@REM distributed with this work for additional information
+@REM regarding copyright ownership.  The ASF licenses this file
+@REM to you under the Apache License, Version 2.0 (the
+@REM "License"); you may not use this file except in compliance
+@REM with the License.  You may obtain a copy of the License at
+@REM
+@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing,
+@REM software distributed under the License is distributed on an
+@REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@REM KIND, either express or implied.  See the License for the
+@REM specific language governing permissions and limitations
+@REM under the License.
+@REM ----------------------------------------------------------------------------
+
+@REM ----------------------------------------------------------------------------
+@REM Apache Maven Wrapper startup batch script, version 3.3.2
+@REM
+@REM Optional ENV vars
+@REM   MVNW_REPOURL - repo url base for downloading maven distribution
+@REM   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+@REM   MVNW_VERBOSE - true: enable verbose log; others: silence the output
+@REM ----------------------------------------------------------------------------
+
+@IF "%__MVNW_ARG0_NAME__%"=="" (SET __MVNW_ARG0_NAME__=%~nx0)
+@SET __MVNW_CMD__=
+@SET __MVNW_ERROR__=
+@SET __MVNW_PSMODULEP_SAVE=%PSModulePath%
+@SET PSModulePath=
+@FOR /F "usebackq tokens=1* delims==" %%A IN (`powershell -noprofile "& {$scriptDir='%~dp0'; $script='%__MVNW_ARG0_NAME__%'; icm -ScriptBlock ([Scriptblock]::Create((Get-Content -Raw '%~f0'))) -NoNewScope}"`) DO @(
+  IF "%%A"=="MVN_CMD" (set __MVNW_CMD__=%%B) ELSE IF "%%B"=="" (echo %%A) ELSE (echo %%A=%%B)
+)
+@SET PSModulePath=%__MVNW_PSMODULEP_SAVE%
+@SET __MVNW_PSMODULEP_SAVE=
+@SET __MVNW_ARG0_NAME__=
+@SET MVNW_USERNAME=
+@SET MVNW_PASSWORD=
+@IF NOT "%__MVNW_CMD__%"=="" (%__MVNW_CMD__% %*)
+@echo Cannot start maven from wrapper >&2 && exit /b 1
+@GOTO :EOF
+: end batch / begin powershell #>
+
+$ErrorActionPreference = "Stop"
+if ($env:MVNW_VERBOSE -eq "true") {
+  $VerbosePreference = "Continue"
+}
+
+# calculate distributionUrl, requires .mvn/wrapper/maven-wrapper.properties
+$distributionUrl = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionUrl
+if (!$distributionUrl) {
+  Write-Error "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+}
+
+switch -wildcard -casesensitive ( $($distributionUrl -replace '^.*/','') ) {
+  "maven-mvnd-*" {
+    $USE_MVND = $true
+    $distributionUrl = $distributionUrl -replace '-bin\.[^.]*$',"-windows-amd64.zip"
+    $MVN_CMD = "mvnd.cmd"
+    break
+  }
+  default {
+    $USE_MVND = $false
+    $MVN_CMD = $script -replace '^mvnw','mvn'
+    break
+  }
+}
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+if ($env:MVNW_REPOURL) {
+  $MVNW_REPO_PATTERN = if ($USE_MVND) { "/org/apache/maven/" } else { "/maven/mvnd/" }
+  $distributionUrl = "$env:MVNW_REPOURL$MVNW_REPO_PATTERN$($distributionUrl -replace '^.*'+$MVNW_REPO_PATTERN,'')"
+}
+$distributionUrlName = $distributionUrl -replace '^.*/',''
+$distributionUrlNameMain = $distributionUrlName -replace '\.[^.]*$','' -replace '-bin$',''
+$MAVEN_HOME_PARENT = "$HOME/.m2/wrapper/dists/$distributionUrlNameMain"
+if ($env:MAVEN_USER_HOME) {
+  $MAVEN_HOME_PARENT = "$env:MAVEN_USER_HOME/wrapper/dists/$distributionUrlNameMain"
+}
+$MAVEN_HOME_NAME = ([System.Security.Cryptography.MD5]::Create().ComputeHash([byte[]][char[]]$distributionUrl) | ForEach-Object {$_.ToString("x2")}) -join ''
+$MAVEN_HOME = "$MAVEN_HOME_PARENT/$MAVEN_HOME_NAME"
+
+if (Test-Path -Path "$MAVEN_HOME" -PathType Container) {
+  Write-Verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"
+  exit $?
+}
+
+if (! $distributionUrlNameMain -or ($distributionUrlName -eq $distributionUrlNameMain)) {
+  Write-Error "distributionUrl is not valid, must end with *-bin.zip, but found $distributionUrl"
+}
+
+# prepare tmp dir
+$TMP_DOWNLOAD_DIR_HOLDER = New-TemporaryFile
+$TMP_DOWNLOAD_DIR = New-Item -Itemtype Directory -Path "$TMP_DOWNLOAD_DIR_HOLDER.dir"
+$TMP_DOWNLOAD_DIR_HOLDER.Delete() | Out-Null
+trap {
+  if ($TMP_DOWNLOAD_DIR.Exists) {
+    try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+    catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+  }
+}
+
+New-Item -Itemtype Directory -Path "$MAVEN_HOME_PARENT" -Force | Out-Null
+
+# Download and Install Apache Maven
+Write-Verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+Write-Verbose "Downloading from: $distributionUrl"
+Write-Verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+$webclient = New-Object System.Net.WebClient
+if ($env:MVNW_USERNAME -and $env:MVNW_PASSWORD) {
+  $webclient.Credentials = New-Object System.Net.NetworkCredential($env:MVNW_USERNAME, $env:MVNW_PASSWORD)
+}
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$webclient.DownloadFile($distributionUrl, "$TMP_DOWNLOAD_DIR/$distributionUrlName") | Out-Null
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+$distributionSha256Sum = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionSha256Sum
+if ($distributionSha256Sum) {
+  if ($USE_MVND) {
+    Write-Error "Checksum validation is not supported for maven-mvnd. `nPlease disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties."
+  }
+  Import-Module $PSHOME\Modules\Microsoft.PowerShell.Utility -Function Get-FileHash
+  if ((Get-FileHash "$TMP_DOWNLOAD_DIR/$distributionUrlName" -Algorithm SHA256).Hash.ToLower() -ne $distributionSha256Sum) {
+    Write-Error "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised. If you updated your Maven version, you need to update the specified distributionSha256Sum property."
+  }
+}
+
+# unzip and move
+Expand-Archive "$TMP_DOWNLOAD_DIR/$distributionUrlName" -DestinationPath "$TMP_DOWNLOAD_DIR" | Out-Null
+Rename-Item -Path "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" -NewName $MAVEN_HOME_NAME | Out-Null
+try {
+  Move-Item -Path "$TMP_DOWNLOAD_DIR/$MAVEN_HOME_NAME" -Destination $MAVEN_HOME_PARENT | Out-Null
+} catch {
+  if (! (Test-Path -Path "$MAVEN_HOME" -PathType Container)) {
+    Write-Error "fail to move MAVEN_HOME"
+  }
+} finally {
+  try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+  catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+}
+
+Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"

--- a/ContentManagement-BE/pom.xml
+++ b/ContentManagement-BE/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.3.5</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+    <groupId>dev.deerops</groupId>
+    <artifactId>ContentManagementAPI</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>ContentManagementAPI</name>
+    <description>ContentManagementAPI</description>
+    <url/>
+    <licenses>
+        <license/>
+    </licenses>
+    <developers>
+        <developer/>
+    </developers>
+    <scm>
+        <connection/>
+        <developerConnection/>
+        <tag/>
+        <url/>
+    </scm>
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.5.0</version>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/ContentManagement-BE/src/main/java/dev/deerops/contentmanagementapi/ContentManagementApiApplication.java
+++ b/ContentManagement-BE/src/main/java/dev/deerops/contentmanagementapi/ContentManagementApiApplication.java
@@ -1,0 +1,13 @@
+package dev.deerops.contentmanagementapi;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class ContentManagementApiApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(ContentManagementApiApplication.class, args);
+    }
+
+}

--- a/ContentManagement-BE/src/main/java/dev/deerops/contentmanagementapi/auth/config/SecurityConfig.java
+++ b/ContentManagement-BE/src/main/java/dev/deerops/contentmanagementapi/auth/config/SecurityConfig.java
@@ -1,0 +1,26 @@
+package dev.deerops.contentmanagementapi.auth.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return  http
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(auth -> auth
+                        .anyRequest().permitAll()
+                ).build();
+    }
+
+}

--- a/ContentManagement-BE/src/main/java/dev/deerops/contentmanagementapi/common/util/exception/GlobalHandleException.java
+++ b/ContentManagement-BE/src/main/java/dev/deerops/contentmanagementapi/common/util/exception/GlobalHandleException.java
@@ -1,0 +1,31 @@
+package dev.deerops.contentmanagementapi.common.util.exception;
+
+import dev.deerops.contentmanagementapi.common.util.result.ApiResponse;
+import dev.deerops.contentmanagementapi.common.util.result.ApiResponseHelper;
+import dev.deerops.contentmanagementapi.content.model.util.exception.ContentLimitExceededException;
+import dev.deerops.contentmanagementapi.content.model.util.exception.NotFoundContent;
+import dev.deerops.contentmanagementapi.content.model.util.exception.NullOrEmptyContentException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class GlobalHandleException {
+
+    @ExceptionHandler(NullOrEmptyContentException.class)
+    public ResponseEntity<?> handleNullOrEmptyContentException() {
+        return new ResponseEntity<>(ApiResponseHelper.NULL_OR_EMPTY_CONTENT(), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(NotFoundContent.class)
+    public ResponseEntity<?> handleNotFoundContentException() {
+        return new ResponseEntity<>(ApiResponseHelper.NOT_FOUND_CONTENT(),HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(ContentLimitExceededException.class)
+    public ResponseEntity<?> handleContentLimitExceededException() {
+        return new ResponseEntity<>(ApiResponseHelper.EXCEEDED_CONTENT(), HttpStatus.BAD_REQUEST);
+    }
+
+}

--- a/ContentManagement-BE/src/main/java/dev/deerops/contentmanagementapi/common/util/result/ApiResponse.java
+++ b/ContentManagement-BE/src/main/java/dev/deerops/contentmanagementapi/common/util/result/ApiResponse.java
@@ -1,0 +1,46 @@
+package dev.deerops.contentmanagementapi.common.util.result;
+
+public class ApiResponse <T>{
+
+    private boolean status;
+
+    private String message;
+
+    private T data;
+
+
+    public ApiResponse(boolean status, String message, T data) {
+        this.status = status;
+        this.message = message;
+        this.data = data;
+    }
+
+    public ApiResponse(boolean status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+    public boolean isStatus() {
+        return status;
+    }
+
+    public void setStatus(boolean status) {
+        this.status = status;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public T getData() {
+        return data;
+    }
+
+    public void setData(T data) {
+        this.data = data;
+    }
+}

--- a/ContentManagement-BE/src/main/java/dev/deerops/contentmanagementapi/common/util/result/ApiResponseHelper.java
+++ b/ContentManagement-BE/src/main/java/dev/deerops/contentmanagementapi/common/util/result/ApiResponseHelper.java
@@ -1,0 +1,42 @@
+package dev.deerops.contentmanagementapi.common.util.result;
+
+import dev.deerops.contentmanagementapi.content.model.dto.response.ContentResponse;
+
+import java.util.List;
+
+public class ApiResponseHelper {
+
+    // Success Response
+
+    public static <T> ApiResponse<T> CREATE(T data) {
+        return new ApiResponse<>(true, "Create content", data);
+    }
+
+    public static <T> ApiResponse<T>  UPDATE(T data) {
+        return new ApiResponse<>(true, "Update content", data);
+    }
+
+    public static <T> ApiResponse<T> GET_CONTENT(T data) {
+        return new ApiResponse<>(true, "Content is", data);
+    }
+
+    public static <T> ApiResponse <T> GET_CONTENT_LIST(T data) {
+        return new ApiResponse<>(true, "Content list", data);
+    }
+
+    // Exceptions Response
+
+    public static ExceptionResponse NULL_OR_EMPTY_CONTENT() {
+        return new ExceptionResponse(false, "Null or empty content");
+    }
+
+    public static ExceptionResponse NOT_FOUND_CONTENT() {
+        return new ExceptionResponse(false, "Not found content");
+    }
+
+    public static ExceptionResponse EXCEEDED_CONTENT(){
+        return new ExceptionResponse(false, "Exceeded content, max 5");
+    }
+
+
+}

--- a/ContentManagement-BE/src/main/java/dev/deerops/contentmanagementapi/common/util/result/ExceptionResponse.java
+++ b/ContentManagement-BE/src/main/java/dev/deerops/contentmanagementapi/common/util/result/ExceptionResponse.java
@@ -1,0 +1,27 @@
+package dev.deerops.contentmanagementapi.common.util.result;
+
+public class ExceptionResponse {
+    private boolean status;
+    private String message;
+
+    public ExceptionResponse(boolean status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+    public boolean isStatus() {
+        return status;
+    }
+
+    public void setStatus(boolean status) {
+        this.status = status;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+}

--- a/ContentManagement-BE/src/main/java/dev/deerops/contentmanagementapi/content/controller/ContentController.java
+++ b/ContentManagement-BE/src/main/java/dev/deerops/contentmanagementapi/content/controller/ContentController.java
@@ -1,0 +1,66 @@
+package dev.deerops.contentmanagementapi.content.controller;
+
+import dev.deerops.contentmanagementapi.common.util.result.ApiResponse;
+import dev.deerops.contentmanagementapi.content.model.dto.request.CreateNewContentRequest;
+import dev.deerops.contentmanagementapi.content.model.dto.request.VisibleContentRequest;
+import dev.deerops.contentmanagementapi.content.model.dto.response.ContentDetailsResponse;
+import dev.deerops.contentmanagementapi.content.model.dto.response.ContentResponse;
+import dev.deerops.contentmanagementapi.content.service.ContentService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/content")
+public class ContentController {
+
+    private final ContentService contentService;
+
+    public ContentController(ContentService contentService) {
+        this.contentService = contentService;
+    }
+
+    @PostMapping("/create")
+    public ResponseEntity<ApiResponse<ContentResponse>> createNewContent(@RequestBody CreateNewContentRequest contentRequest) {
+
+        return contentService.createNewContent(contentRequest);
+    }
+
+    @GetMapping("/content/{contentId}")
+    public ResponseEntity<ApiResponse<ContentResponse>> getContentByContentIdForPath(@PathVariable String contentId) {
+        return contentService.getContentByContentIdForPath(contentId);
+    }
+
+    @GetMapping("/contents")
+    public ResponseEntity<ApiResponse<List<ContentResponse>>> getAllContentInContentResponse() {
+        return contentService.getAllContentInContentResponse();
+    }
+
+    @GetMapping("/contents/{contentId}/details")
+    public ResponseEntity<ApiResponse<ContentDetailsResponse>> getContentDetailsByContentIdForPath(@PathVariable String contentId) {
+        return contentService.getContentDetailsByContentIdForPath(contentId);
+    }
+
+    @GetMapping("/contents/details")
+    public ResponseEntity<ApiResponse<List<ContentDetailsResponse>>> getAllContentInContentDetailsResponse() {
+        return contentService.getAllContentInContentDetailsResponse();
+    }
+
+    @PutMapping("/update/visibility")
+    public ResponseEntity<ApiResponse<ContentResponse>> publishContent(@RequestBody VisibleContentRequest visibleContentRequest) {
+        return contentService.publishContent(visibleContentRequest);
+    }
+
+    @GetMapping("/contents/published")
+    public ResponseEntity<ApiResponse<List<ContentResponse>>> getJustPublishedContents() {
+        return contentService.getJustPublishedContents();
+    }
+
+    @GetMapping("/contents/unpublished")
+    public ResponseEntity<ApiResponse<List<ContentResponse>>> getJustUnpublishedContents(){
+        return contentService.getJustUnpublishedContents();
+    }
+
+
+}

--- a/ContentManagement-BE/src/main/java/dev/deerops/contentmanagementapi/content/model/converter/ContentConverter.java
+++ b/ContentManagement-BE/src/main/java/dev/deerops/contentmanagementapi/content/model/converter/ContentConverter.java
@@ -1,0 +1,61 @@
+package dev.deerops.contentmanagementapi.content.model.converter;
+
+import dev.deerops.contentmanagementapi.content.model.dto.request.CreateNewContentRequest;
+import dev.deerops.contentmanagementapi.content.model.dto.request.VisibleContentRequest;
+import dev.deerops.contentmanagementapi.content.model.dto.response.ContentDetailsResponse;
+import dev.deerops.contentmanagementapi.content.model.dto.response.ContentResponse;
+import dev.deerops.contentmanagementapi.content.model.entity.ContentEntity;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ContentConverter {
+
+
+    public ContentEntity fromCreateNewContentRequestToEntity(CreateNewContentRequest request) {
+        ContentEntity contentEntity = new ContentEntity();
+
+        contentEntity.setContentTitle(request.getContentTitle());
+
+        contentEntity.setContentDescription(request.getContentDescription());
+
+        return contentEntity;
+    }
+
+    public ContentEntity fromVisibleContentRequestToEntity(VisibleContentRequest request) {
+        ContentEntity contentEntity = new ContentEntity();
+
+        contentEntity.setContentId(request.getContentId());
+
+        contentEntity.setVisibleContent(request.isVisibleContent());
+
+        return contentEntity;
+    }
+
+    public ContentResponse fromEntityToContentResponse(ContentEntity contentEntity) {
+        ContentResponse contentResponse = new ContentResponse();
+
+        contentResponse.setContentTitle(contentEntity.getContentTitle());
+
+        contentResponse.setContentDescription(contentEntity.getContentDescription());
+
+        return contentResponse;
+    }
+
+
+    public ContentDetailsResponse fromEntityToContentDetailsResponse(ContentEntity contentEntity) {
+        ContentDetailsResponse contentDetailsResponse = new ContentDetailsResponse();
+
+        contentDetailsResponse.setContentTitle(contentEntity.getContentTitle());
+
+        contentDetailsResponse.setContentDescription(contentEntity.getContentDescription());
+
+        contentDetailsResponse.setVisibleContent(contentEntity.isVisibleContent());
+
+        contentDetailsResponse.setContentId(contentEntity.getContentId());
+
+        contentDetailsResponse.setPublishDate(contentEntity.getPublishDate());
+
+        return contentDetailsResponse;
+    }
+
+}

--- a/ContentManagement-BE/src/main/java/dev/deerops/contentmanagementapi/content/model/dto/request/CreateNewContentRequest.java
+++ b/ContentManagement-BE/src/main/java/dev/deerops/contentmanagementapi/content/model/dto/request/CreateNewContentRequest.java
@@ -1,0 +1,33 @@
+package dev.deerops.contentmanagementapi.content.model.dto.request;
+
+import jakarta.persistence.Lob;
+
+import java.time.LocalDate;
+
+public class CreateNewContentRequest {
+    private String contentTitle;
+
+    private String contentDescription;
+
+
+    public CreateNewContentRequest(String contentTitle, String contentDescription) {
+        this.contentTitle = contentTitle;
+        this.contentDescription = contentDescription;
+    }
+
+    public String getContentTitle() {
+        return contentTitle;
+    }
+
+    public void setContentTitle(String contentTitle) {
+        this.contentTitle = contentTitle;
+    }
+
+    public String getContentDescription() {
+        return contentDescription;
+    }
+
+    public void setContentDescription(String contentDescription) {
+        this.contentDescription = contentDescription;
+    }
+}

--- a/ContentManagement-BE/src/main/java/dev/deerops/contentmanagementapi/content/model/dto/request/VisibleContentRequest.java
+++ b/ContentManagement-BE/src/main/java/dev/deerops/contentmanagementapi/content/model/dto/request/VisibleContentRequest.java
@@ -1,0 +1,28 @@
+package dev.deerops.contentmanagementapi.content.model.dto.request;
+
+public class VisibleContentRequest {
+    private String contentId;
+
+    private boolean visibleContent;
+
+    public VisibleContentRequest(String contentId, boolean visibleContent) {
+        this.contentId = contentId;
+        this.visibleContent = visibleContent;
+    }
+
+    public String getContentId() {
+        return contentId;
+    }
+
+    public void setContentId(String contentId) {
+        this.contentId = contentId;
+    }
+
+    public boolean isVisibleContent() {
+        return visibleContent;
+    }
+
+    public void setVisibleContent(boolean visibleContent) {
+        this.visibleContent = visibleContent;
+    }
+}

--- a/ContentManagement-BE/src/main/java/dev/deerops/contentmanagementapi/content/model/dto/response/ContentDetailsResponse.java
+++ b/ContentManagement-BE/src/main/java/dev/deerops/contentmanagementapi/content/model/dto/response/ContentDetailsResponse.java
@@ -1,0 +1,69 @@
+package dev.deerops.contentmanagementapi.content.model.dto.response;
+
+import java.time.LocalDate;
+
+public class ContentDetailsResponse {
+
+    private String contentId;
+
+    private String contentTitle;
+
+    private String contentDescription;
+
+    private LocalDate publishDate;
+
+    private boolean visibleContent;
+
+
+    public ContentDetailsResponse() {
+    }
+
+    public ContentDetailsResponse(String contentId, String contentTitle, String contentDescription, LocalDate publishDate, boolean visibleContent) {
+        this.contentId = contentId;
+        this.contentTitle = contentTitle;
+        this.contentDescription = contentDescription;
+        this.publishDate = publishDate;
+        this.visibleContent = visibleContent;
+    }
+
+
+    public String getContentId() {
+        return contentId;
+    }
+
+    public void setContentId(String contentId) {
+        this.contentId = contentId;
+    }
+
+    public String getContentTitle() {
+        return contentTitle;
+    }
+
+    public void setContentTitle(String contentTitle) {
+        this.contentTitle = contentTitle;
+    }
+
+    public String getContentDescription() {
+        return contentDescription;
+    }
+
+    public void setContentDescription(String contentDescription) {
+        this.contentDescription = contentDescription;
+    }
+
+    public LocalDate getPublishDate() {
+        return publishDate;
+    }
+
+    public void setPublishDate(LocalDate publishDate) {
+        this.publishDate = publishDate;
+    }
+
+    public boolean isVisibleContent() {
+        return visibleContent;
+    }
+
+    public void setVisibleContent(boolean visibleContent) {
+        this.visibleContent = visibleContent;
+    }
+}

--- a/ContentManagement-BE/src/main/java/dev/deerops/contentmanagementapi/content/model/dto/response/ContentResponse.java
+++ b/ContentManagement-BE/src/main/java/dev/deerops/contentmanagementapi/content/model/dto/response/ContentResponse.java
@@ -1,0 +1,32 @@
+package dev.deerops.contentmanagementapi.content.model.dto.response;
+
+public class ContentResponse {
+
+    private String contentTitle;
+
+    private String contentDescription;
+
+    public ContentResponse() {
+    }
+
+    public ContentResponse(String contentTitle, String contentDescription) {
+        this.contentTitle = contentTitle;
+        this.contentDescription = contentDescription;
+    }
+
+    public String getContentTitle() {
+        return contentTitle;
+    }
+
+    public void setContentTitle(String contentTitle) {
+        this.contentTitle = contentTitle;
+    }
+
+    public String getContentDescription() {
+        return contentDescription;
+    }
+
+    public void setContentDescription(String contentDescription) {
+        this.contentDescription = contentDescription;
+    }
+}

--- a/ContentManagement-BE/src/main/java/dev/deerops/contentmanagementapi/content/model/entity/ContentEntity.java
+++ b/ContentManagement-BE/src/main/java/dev/deerops/contentmanagementapi/content/model/entity/ContentEntity.java
@@ -1,0 +1,67 @@
+package dev.deerops.contentmanagementapi.content.model.entity;
+
+import jakarta.persistence.*;
+import jakarta.transaction.Transactional;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.UuidGenerator;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "content")
+public class ContentEntity {
+    @Id
+    @GeneratedValue
+    @UuidGenerator
+    private String contentId;
+
+    private String contentTitle;
+
+    @Lob
+    private String contentDescription;
+
+    private LocalDate publishDate;
+
+    private boolean visibleContent;
+
+
+    public String getContentId() {
+        return contentId;
+    }
+
+    public void setContentId(String contentId) {
+        this.contentId = contentId;
+    }
+
+    public String getContentTitle() {
+        return contentTitle;
+    }
+
+    public void setContentTitle(String contentTitle) {
+        this.contentTitle = contentTitle;
+    }
+
+    public String getContentDescription() {
+        return contentDescription;
+    }
+
+    public void setContentDescription(String contentDescription) {
+        this.contentDescription = contentDescription;
+    }
+
+    public LocalDate getPublishDate() {
+        return publishDate;
+    }
+
+    public void setPublishDate(LocalDate publishDate) {
+        this.publishDate = publishDate;
+    }
+
+    public boolean isVisibleContent() {
+        return visibleContent;
+    }
+
+    public void setVisibleContent(boolean visibleContent) {
+        this.visibleContent = visibleContent;
+    }
+}

--- a/ContentManagement-BE/src/main/java/dev/deerops/contentmanagementapi/content/model/util/exception/ContentLimitExceededException.java
+++ b/ContentManagement-BE/src/main/java/dev/deerops/contentmanagementapi/content/model/util/exception/ContentLimitExceededException.java
@@ -1,0 +1,10 @@
+package dev.deerops.contentmanagementapi.content.model.util.exception;
+
+public class ContentLimitExceededException extends RuntimeException{
+    public ContentLimitExceededException(String message) {
+        super(message);
+    }
+
+    public ContentLimitExceededException() {
+    }
+}

--- a/ContentManagement-BE/src/main/java/dev/deerops/contentmanagementapi/content/model/util/exception/NotFoundContent.java
+++ b/ContentManagement-BE/src/main/java/dev/deerops/contentmanagementapi/content/model/util/exception/NotFoundContent.java
@@ -1,0 +1,10 @@
+package dev.deerops.contentmanagementapi.content.model.util.exception;
+
+public class NotFoundContent extends RuntimeException {
+    public NotFoundContent(String message) {
+        super(message);
+    }
+
+    public NotFoundContent() {
+    }
+}

--- a/ContentManagement-BE/src/main/java/dev/deerops/contentmanagementapi/content/model/util/exception/NullOrEmptyContentException.java
+++ b/ContentManagement-BE/src/main/java/dev/deerops/contentmanagementapi/content/model/util/exception/NullOrEmptyContentException.java
@@ -1,0 +1,10 @@
+package dev.deerops.contentmanagementapi.content.model.util.exception;
+
+public class NullOrEmptyContentException extends RuntimeException{
+    public NullOrEmptyContentException(String message) {
+        super(message);
+    }
+
+    public NullOrEmptyContentException() {
+    }
+}

--- a/ContentManagement-BE/src/main/java/dev/deerops/contentmanagementapi/content/model/util/validation/ContentValidation.java
+++ b/ContentManagement-BE/src/main/java/dev/deerops/contentmanagementapi/content/model/util/validation/ContentValidation.java
@@ -1,0 +1,19 @@
+package dev.deerops.contentmanagementapi.content.model.util.validation;
+
+import dev.deerops.contentmanagementapi.content.model.util.exception.NullOrEmptyContentException;
+
+public class ContentValidation {
+
+    public static void contentTitleAndDescriptionValidation(String title,String description) {
+        if(title == null || title.trim().isEmpty() || description == null || description.trim().isEmpty()) {
+            throw new NullOrEmptyContentException();
+        }
+    }
+
+    public static void contentIdValidation(String contentId) {
+        if(contentId == null || contentId.trim().isEmpty()) {
+            throw new NullOrEmptyContentException();
+        }
+    }
+
+}

--- a/ContentManagement-BE/src/main/java/dev/deerops/contentmanagementapi/content/repository/ContentRepository.java
+++ b/ContentManagement-BE/src/main/java/dev/deerops/contentmanagementapi/content/repository/ContentRepository.java
@@ -1,0 +1,13 @@
+package dev.deerops.contentmanagementapi.content.repository;
+
+import dev.deerops.contentmanagementapi.content.model.entity.ContentEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ContentRepository extends JpaRepository<ContentEntity,String> {
+    List<ContentEntity> findByVisibleContentIsTrue();
+    List<ContentEntity> findByVisibleContentIsFalse();
+}

--- a/ContentManagement-BE/src/main/java/dev/deerops/contentmanagementapi/content/service/ContentService.java
+++ b/ContentManagement-BE/src/main/java/dev/deerops/contentmanagementapi/content/service/ContentService.java
@@ -1,0 +1,30 @@
+package dev.deerops.contentmanagementapi.content.service;
+
+import dev.deerops.contentmanagementapi.common.util.result.ApiResponse;
+import dev.deerops.contentmanagementapi.content.model.dto.request.CreateNewContentRequest;
+import dev.deerops.contentmanagementapi.content.model.dto.request.VisibleContentRequest;
+import dev.deerops.contentmanagementapi.content.model.dto.response.ContentDetailsResponse;
+import dev.deerops.contentmanagementapi.content.model.dto.response.ContentResponse;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+
+public interface ContentService {
+
+    ResponseEntity<ApiResponse<ContentResponse>> createNewContent(CreateNewContentRequest createNewContentRequest);
+
+    ResponseEntity<ApiResponse<ContentResponse>> getContentByContentIdForPath(String contentId);
+
+    ResponseEntity<ApiResponse<List<ContentResponse>>> getAllContentInContentResponse();
+
+    ResponseEntity<ApiResponse<ContentDetailsResponse>> getContentDetailsByContentIdForPath(String contentId);
+
+    ResponseEntity<ApiResponse<List<ContentDetailsResponse>>> getAllContentInContentDetailsResponse();
+
+    ResponseEntity<ApiResponse<ContentResponse>> publishContent(VisibleContentRequest visibleContentRequest);
+
+    ResponseEntity<ApiResponse<List<ContentResponse>>> getJustPublishedContents();
+
+    ResponseEntity<ApiResponse<List<ContentResponse>>> getJustUnpublishedContents();
+
+}

--- a/ContentManagement-BE/src/main/java/dev/deerops/contentmanagementapi/content/service/impl/ContentServiceImpl.java
+++ b/ContentManagement-BE/src/main/java/dev/deerops/contentmanagementapi/content/service/impl/ContentServiceImpl.java
@@ -1,0 +1,150 @@
+package dev.deerops.contentmanagementapi.content.service.impl;
+
+import dev.deerops.contentmanagementapi.common.util.result.ApiResponse;
+import dev.deerops.contentmanagementapi.common.util.result.ApiResponseHelper;
+import dev.deerops.contentmanagementapi.content.model.converter.ContentConverter;
+import dev.deerops.contentmanagementapi.content.model.dto.request.CreateNewContentRequest;
+import dev.deerops.contentmanagementapi.content.model.dto.request.VisibleContentRequest;
+import dev.deerops.contentmanagementapi.content.model.dto.response.ContentDetailsResponse;
+import dev.deerops.contentmanagementapi.content.model.dto.response.ContentResponse;
+import dev.deerops.contentmanagementapi.content.model.entity.ContentEntity;
+import dev.deerops.contentmanagementapi.content.model.util.exception.ContentLimitExceededException;
+import dev.deerops.contentmanagementapi.content.model.util.exception.NotFoundContent;
+import dev.deerops.contentmanagementapi.content.model.util.exception.NullOrEmptyContentException;
+import dev.deerops.contentmanagementapi.content.model.util.validation.ContentValidation;
+import dev.deerops.contentmanagementapi.content.repository.ContentRepository;
+import dev.deerops.contentmanagementapi.content.service.ContentService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+public class ContentServiceImpl implements ContentService {
+
+    private final ContentRepository contentRepository;
+
+    private final ContentConverter contentConverter;
+
+    public ContentServiceImpl(ContentRepository contentRepository, ContentConverter contentConverter) {
+        this.contentRepository = contentRepository;
+        this.contentConverter = contentConverter;
+    }
+
+    @Override
+    public ResponseEntity<ApiResponse<ContentResponse>> createNewContent(CreateNewContentRequest createNewContentRequest) {
+
+        List<ContentEntity> contentCountList = contentRepository.findAll();
+
+        if (contentCountList.size() >= 5){
+            throw new ContentLimitExceededException();
+        }
+
+
+        ContentEntity contentEntity = contentConverter.fromCreateNewContentRequestToEntity(createNewContentRequest);
+
+        ContentValidation.contentTitleAndDescriptionValidation(
+                contentEntity.getContentTitle(), contentEntity.getContentDescription()
+        );
+
+        contentEntity.setVisibleContent(false);
+
+        ContentResponse contentResponse = contentConverter.fromEntityToContentResponse(
+                contentRepository.save(contentEntity)
+        );
+
+      return new ResponseEntity<>(ApiResponseHelper.CREATE(contentResponse), HttpStatus.CREATED);
+    }
+
+    @Override
+    public ResponseEntity<ApiResponse<ContentResponse>> getContentByContentIdForPath(String contentId) {
+
+        ContentValidation.contentIdValidation(contentId);
+
+        ContentEntity contentEntity = contentRepository.findById(contentId).orElseThrow(NotFoundContent::new);
+
+        ContentResponse contentResponse = contentConverter.fromEntityToContentResponse(contentEntity);
+
+
+        return new ResponseEntity<>(ApiResponseHelper.GET_CONTENT(contentResponse), HttpStatus.OK);
+
+
+    }
+
+    @Override
+    public ResponseEntity<ApiResponse<List<ContentResponse>>> getAllContentInContentResponse() {
+        List<ContentEntity> contentEntityList = contentRepository.findAll();
+
+        List<ContentResponse> contentResponseList = contentEntityList.stream()
+                .map(
+                        contentConverter::fromEntityToContentResponse).toList();
+
+
+        return new ResponseEntity<>(ApiResponseHelper.GET_CONTENT_LIST(contentResponseList), HttpStatus.OK);
+
+    }
+
+    @Override
+    public ResponseEntity<ApiResponse<ContentDetailsResponse>> getContentDetailsByContentIdForPath(String contentId) {
+
+        ContentValidation.contentIdValidation(contentId);
+
+        ContentEntity contentEntity = contentRepository.findById(contentId).orElseThrow(NotFoundContent::new);
+
+        ContentDetailsResponse contentDetailsResponse = contentConverter.fromEntityToContentDetailsResponse(contentEntity);
+
+        return new ResponseEntity<>(ApiResponseHelper.GET_CONTENT(contentDetailsResponse), HttpStatus.OK);
+    }
+
+    @Override
+    public ResponseEntity<ApiResponse<List<ContentDetailsResponse>>> getAllContentInContentDetailsResponse() {
+        List<ContentEntity> contentEntityList = contentRepository.findAll();
+
+        List<ContentDetailsResponse> contentDetailsResponseList = contentEntityList.stream()
+                .map(
+                        contentConverter::fromEntityToContentDetailsResponse).toList();
+        return new ResponseEntity<>(ApiResponseHelper.GET_CONTENT_LIST(contentDetailsResponseList), HttpStatus.OK);
+    }
+
+
+    @Override
+    public ResponseEntity<ApiResponse<ContentResponse>> publishContent(VisibleContentRequest visibleContentRequest) {
+
+        ContentValidation.contentIdValidation(visibleContentRequest.getContentId());
+
+        ContentEntity contentEntity = contentRepository.findById(visibleContentRequest.getContentId())
+                .orElseThrow(NotFoundContent::new);
+
+        contentEntity.setVisibleContent(visibleContentRequest.isVisibleContent());
+
+        if(visibleContentRequest.isVisibleContent()) {
+            contentEntity.setPublishDate(LocalDate.now());
+        }
+
+        ContentResponse contentResponse = contentConverter.fromEntityToContentResponse(contentRepository.save(contentEntity));
+
+        return new ResponseEntity<>(ApiResponseHelper.UPDATE(contentResponse),HttpStatus.OK);
+    }
+
+    @Override
+    public ResponseEntity<ApiResponse<List<ContentResponse>>> getJustPublishedContents() {
+        List<ContentEntity> contentEntityList = contentRepository.findByVisibleContentIsTrue();
+
+        List<ContentResponse> contentResponseList = contentEntityList.stream()
+                .map(contentConverter::fromEntityToContentResponse).toList();
+
+        return new ResponseEntity<>(ApiResponseHelper.GET_CONTENT_LIST(contentResponseList), HttpStatus.OK);
+    }
+
+    @Override
+    public ResponseEntity<ApiResponse<List<ContentResponse>>> getJustUnpublishedContents() {
+        List<ContentEntity> contentEntityList = contentRepository.findByVisibleContentIsFalse();
+
+        List<ContentResponse> contentResponseList = contentEntityList.stream()
+                .map(contentConverter::fromEntityToContentResponse).toList();
+
+        return new ResponseEntity<>(ApiResponseHelper.GET_CONTENT_LIST(contentResponseList), HttpStatus.OK);
+    }
+}

--- a/ContentManagement-BE/src/main/resources/application.properties
+++ b/ContentManagement-BE/src/main/resources/application.properties
@@ -1,0 +1,11 @@
+spring.application.name=ContentManagementAPI
+spring.security.user.password=1511
+spring.security.user.name=admin
+spring.datasource.url=jdbc:postgresql://localhost:5432/db
+spring.datasource.username=postgres
+spring.datasource.password=1511
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+logging.level.org.hibernate.SQL=DEBUG
+spring.datasource.hikari.auto-commit= false


### PR DESCRIPTION
- Implemented content creation with validation for title and description.
- Added content visibility management with `publish` and `unpublish` functionality.
- Created API responses for fetching single and multiple content details.
- Introduced content visibility filters for retrieving published and unpublished content.
- Enforced content limit: Maximum 5 contents can be created.
- Added exception handling for null/empty content and exceeded content limits.
- Integrated validation for content ID and content details.

- Disabled CSRF protection for ease of use during development.
- Configured global authorization allowing all requests without restrictions.
- Enabled basic security configuration to set up a foundation for future enhancements.
- Placeholder setup for future security features like JWT authentication and role-based access control.

This commit includes changes to:
- Content entity for title, description, visibility, and publish date management.
- `ContentService` to handle content creation, publishing, and retrieving content.
- Updated `ContentRepository` for querying published and unpublished content.
- Basic security configuration with CSRF disabled and global authorization setup.