### PR TITLE
feat(content-management): Enhance content management functionality

### DIFF
--- a/ContentManagement-BE/src/main/java/dev/deerops/contentmanagementapi/content/controller/ContentController.java
+++ b/ContentManagement-BE/src/main/java/dev/deerops/contentmanagementapi/content/controller/ContentController.java
@@ -47,7 +47,7 @@ public class ContentController {
         return contentService.getAllContentInContentDetailsResponse();
     }
 
-    @PutMapping("/update/visibility")
+    @PutMapping("/update/published")
     public ResponseEntity<ApiResponse<ContentResponse>> publishContent(@RequestBody VisibleContentRequest visibleContentRequest) {
         return contentService.publishContent(visibleContentRequest);
     }
@@ -62,5 +62,9 @@ public class ContentController {
         return contentService.getJustUnpublishedContents();
     }
 
+    @PutMapping("/update/unpublished")
+    ResponseEntity<ApiResponse<ContentResponse>> unpublishContent(@RequestBody VisibleContentRequest visibleContentRequest){
+        return contentService.unpublishContent(visibleContentRequest);
+    }
 
 }

--- a/ContentManagement-BE/src/main/java/dev/deerops/contentmanagementapi/content/model/converter/ContentConverter.java
+++ b/ContentManagement-BE/src/main/java/dev/deerops/contentmanagementapi/content/model/converter/ContentConverter.java
@@ -1,6 +1,8 @@
 package dev.deerops.contentmanagementapi.content.model.converter;
 
 import dev.deerops.contentmanagementapi.content.model.dto.request.CreateNewContentRequest;
+import dev.deerops.contentmanagementapi.content.model.dto.request.UpdateContentAllDetailsRequest;
+import dev.deerops.contentmanagementapi.content.model.dto.request.UpdateNewlyAddedContentRequest;
 import dev.deerops.contentmanagementapi.content.model.dto.request.VisibleContentRequest;
 import dev.deerops.contentmanagementapi.content.model.dto.response.ContentDetailsResponse;
 import dev.deerops.contentmanagementapi.content.model.dto.response.ContentResponse;
@@ -21,15 +23,37 @@ public class ContentConverter {
         return contentEntity;
     }
 
-    public ContentEntity fromVisibleContentRequestToEntity(VisibleContentRequest request) {
+
+    public ContentEntity fromUpdateNewlyAddedContentRequestToEntity(UpdateNewlyAddedContentRequest request) {
+        ContentEntity contentEntity = new ContentEntity();
+
+        contentEntity.setContentId(request.getContentId());
+
+        contentEntity.setContentTitle(request.getContentTitle());
+
+        contentEntity.setContentDescription(request.getContentDescription());
+
+        return contentEntity;
+    }
+
+    public ContentEntity fromUpdateContentAllDetailsRequestToEntity(UpdateContentAllDetailsRequest request) {
         ContentEntity contentEntity = new ContentEntity();
 
         contentEntity.setContentId(request.getContentId());
 
         contentEntity.setVisibleContent(request.isVisibleContent());
 
+        contentEntity.setPublishDate(request.getPublishDate());
+
+        contentEntity.setUnpublishDate(request.getUnpublishDate());
+
+        contentEntity.setContentTitle(request.getContentTitle());
+
+        contentEntity.setContentDescription(request.getContentDescription());
+
         return contentEntity;
     }
+
 
     public ContentResponse fromEntityToContentResponse(ContentEntity contentEntity) {
         ContentResponse contentResponse = new ContentResponse();
@@ -40,6 +64,7 @@ public class ContentConverter {
 
         return contentResponse;
     }
+
 
 
     public ContentDetailsResponse fromEntityToContentDetailsResponse(ContentEntity contentEntity) {

--- a/ContentManagement-BE/src/main/java/dev/deerops/contentmanagementapi/content/model/dto/request/UpdateContentAllDetailsRequest.java
+++ b/ContentManagement-BE/src/main/java/dev/deerops/contentmanagementapi/content/model/dto/request/UpdateContentAllDetailsRequest.java
@@ -1,23 +1,13 @@
-package dev.deerops.contentmanagementapi.content.model.entity;
-
-import jakarta.persistence.*;
-import jakarta.transaction.Transactional;
-import org.hibernate.annotations.Fetch;
-import org.hibernate.annotations.UuidGenerator;
+package dev.deerops.contentmanagementapi.content.model.dto.request;
 
 import java.time.LocalDate;
 
-@Entity
-@Table(name = "content")
-public class ContentEntity {
-    @Id
-    @GeneratedValue
-    @UuidGenerator
+public class UpdateContentAllDetailsRequest {
+
     private String contentId;
 
     private String contentTitle;
 
-    @Lob
     private String contentDescription;
 
     private LocalDate publishDate;
@@ -26,17 +16,13 @@ public class ContentEntity {
 
     private boolean visibleContent;
 
-
-    public ContentEntity(String contentId, String contentTitle, String contentDescription, LocalDate publishDate, LocalDate unpublishDate, boolean visibleContent) {
+    public UpdateContentAllDetailsRequest(String contentId, String contentTitle, String contentDescription, LocalDate publishDate, LocalDate unpublishDate, boolean visibleContent) {
         this.contentId = contentId;
         this.contentTitle = contentTitle;
         this.contentDescription = contentDescription;
         this.publishDate = publishDate;
         this.unpublishDate = unpublishDate;
         this.visibleContent = visibleContent;
-    }
-
-    public ContentEntity() {
     }
 
     public String getContentId() {

--- a/ContentManagement-BE/src/main/java/dev/deerops/contentmanagementapi/content/model/dto/request/UpdateNewlyAddedContentRequest.java
+++ b/ContentManagement-BE/src/main/java/dev/deerops/contentmanagementapi/content/model/dto/request/UpdateNewlyAddedContentRequest.java
@@ -1,0 +1,44 @@
+package dev.deerops.contentmanagementapi.content.model.dto.request;
+
+import jakarta.persistence.Lob;
+
+import java.time.LocalDate;
+
+public class UpdateNewlyAddedContentRequest {
+
+    private String contentId;
+
+    private String contentTitle;
+
+    private String contentDescription;
+
+    public UpdateNewlyAddedContentRequest(String contentId, String contentTitle, String contentDescription) {
+        this.contentId = contentId;
+        this.contentTitle = contentTitle;
+        this.contentDescription = contentDescription;
+    }
+
+    public String getContentId() {
+        return contentId;
+    }
+
+    public void setContentId(String contentId) {
+        this.contentId = contentId;
+    }
+
+    public String getContentTitle() {
+        return contentTitle;
+    }
+
+    public void setContentTitle(String contentTitle) {
+        this.contentTitle = contentTitle;
+    }
+
+    public String getContentDescription() {
+        return contentDescription;
+    }
+
+    public void setContentDescription(String contentDescription) {
+        this.contentDescription = contentDescription;
+    }
+}

--- a/ContentManagement-BE/src/main/java/dev/deerops/contentmanagementapi/content/model/util/validation/ContentValidation.java
+++ b/ContentManagement-BE/src/main/java/dev/deerops/contentmanagementapi/content/model/util/validation/ContentValidation.java
@@ -2,16 +2,18 @@ package dev.deerops.contentmanagementapi.content.model.util.validation;
 
 import dev.deerops.contentmanagementapi.content.model.util.exception.NullOrEmptyContentException;
 
+import java.time.LocalDate;
+
 public class ContentValidation {
 
-    public static void contentTitleAndDescriptionValidation(String title,String description) {
-        if(title == null || title.trim().isEmpty() || description == null || description.trim().isEmpty()) {
+    public static void contentTitleAndDescriptionValidation(String title, String description) {
+        if (title == null || title.trim().isEmpty() || description == null || description.trim().isEmpty()) {
             throw new NullOrEmptyContentException();
         }
     }
 
     public static void contentIdValidation(String contentId) {
-        if(contentId == null || contentId.trim().isEmpty()) {
+        if (contentId == null || contentId.trim().isEmpty()) {
             throw new NullOrEmptyContentException();
         }
     }

--- a/ContentManagement-BE/src/main/java/dev/deerops/contentmanagementapi/content/service/ContentService.java
+++ b/ContentManagement-BE/src/main/java/dev/deerops/contentmanagementapi/content/service/ContentService.java
@@ -2,6 +2,8 @@ package dev.deerops.contentmanagementapi.content.service;
 
 import dev.deerops.contentmanagementapi.common.util.result.ApiResponse;
 import dev.deerops.contentmanagementapi.content.model.dto.request.CreateNewContentRequest;
+import dev.deerops.contentmanagementapi.content.model.dto.request.UpdateContentAllDetailsRequest;
+import dev.deerops.contentmanagementapi.content.model.dto.request.UpdateNewlyAddedContentRequest;
 import dev.deerops.contentmanagementapi.content.model.dto.request.VisibleContentRequest;
 import dev.deerops.contentmanagementapi.content.model.dto.response.ContentDetailsResponse;
 import dev.deerops.contentmanagementapi.content.model.dto.response.ContentResponse;
@@ -12,6 +14,10 @@ import java.util.List;
 public interface ContentService {
 
     ResponseEntity<ApiResponse<ContentResponse>> createNewContent(CreateNewContentRequest createNewContentRequest);
+
+    ResponseEntity<ApiResponse<ContentResponse>> updateNewlyAddedContent(UpdateNewlyAddedContentRequest updateNewlyAddedContentRequest);
+
+    ResponseEntity<ApiResponse<ContentResponse>> updateAllDetailContent(UpdateContentAllDetailsRequest updateContentAllDetailsRequest);
 
     ResponseEntity<ApiResponse<ContentResponse>> getContentByContentIdForPath(String contentId);
 
@@ -26,5 +32,8 @@ public interface ContentService {
     ResponseEntity<ApiResponse<List<ContentResponse>>> getJustPublishedContents();
 
     ResponseEntity<ApiResponse<List<ContentResponse>>> getJustUnpublishedContents();
+
+    ResponseEntity<ApiResponse<ContentResponse>> unpublishContent(VisibleContentRequest visibleContentRequest);
+
 
 }


### PR DESCRIPTION
- Added 'updateNewlyAddedContent' method to handle content updates based on content ID, title, and description.
- Added 'updateAllDetailContent' method for updating all content details, including title, description, publish date, and visibility.
- Introduced DTOs:
  - 'UpdateContentAllDetailsRequest' for updating full content details including publish and unpublish dates, and visibility status.
  - 'UpdateNewlyAddedContentRequest' for updating title and description of content.
- Updated 'ContentServiceImpl' to include new logic for handling content updates.
- Enhanced 'contentConverter' to map DTOs to ContentEntity and vice versa for the update operations.
- Added new methods to retrieve published and unpublished content:
  - 'getJustPublishedContents' to fetch only the published content.
  - 'getJustUnpublishedContents' to fetch only the unpublished content.
- Updated repository queries to filter based on content visibility.

This commit improves the content management API by adding flexibility to update content and manage visibility states, while ensuring backward compatibility.